### PR TITLE
Corrected error propagation

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ var Converter = module.exports = {};
 
 Converter.convert = function(options, callback) {
   var fromSpec = new Types[options.from]();
-  fromSpec.resolveResources(options, function() {
+  fromSpec.resolveResources(options, function(error) {
+    if (error) {
+      callback(error, null);
+      return;
+    }
     var toSpec = fromSpec.convertTo(options.to);
     callback(null, toSpec);
   });

--- a/lib/types/swagger_1.js
+++ b/lib/types/swagger_1.js
@@ -1,7 +1,5 @@
-var FS = require('fs');
 var Path = require('path');
 var Async = require('async');
-var Request = require('request');
 var Url = require('url');
 var Inherits = require('util').inherits;
 var ConvertToSwagger2 = require('swagger-converter');
@@ -31,29 +29,32 @@ var containsHost = function(urlString) {
 Swagger1.prototype.resolveResources = function(options, callback) {
   var self = this;
   if (options.file) {
-    FS.readFile(options.file, 'utf8', function(err, body) {
-      if (err) throw err;
-      self.spec = Types.parse(body);
+    Types.readFile(options.file, function(err, spec) {
+      if (err) {
+        callback(err);
+        return;
+      }
       var dir = Path.dirname(options.file);
-      Async.parallel(self.spec.apis.map(function(api) {
-        return function(callback) {
+      self.spec = spec;
+      var files = self.spec.apis.map(function(api) {
           var filename = Path.join(dir, api.path);
-          if (filename.indexOf('.json') === -1) filename += '.json';
-          FS.readFile(filename, function(err, body) {
-            callback(err, Types.parse(body));
-          });
-        }
-      }), function(err, apis) {
-        if (err) throw err;
+          if (filename.indexOf('.json') === -1) 
+            filename += '.json';
+          return filename;
+      });
+      Async.map(files, Types.readFile, function (err, apis) {
         self.apis = apis;
-        callback();
-      })
+        callback(err);
+      });
     });
   } else if (options.url) {
     var url = options.url;
-    Request(url, function(err, response, spec) {
-      if (err) throw err;
-      self.spec = Types.parse(spec);
+    Types.requestUrl(url, function(err, spec) {
+      if (err) {
+        callback(error);
+        return;
+      }
+      self.spec = spec;
       var baseUrl = self.spec.basePath;
       if (!baseUrl || !containsHost(baseUrl)) {
         baseUrl = Url.parse(url);
@@ -64,20 +65,15 @@ Swagger1.prototype.resolveResources = function(options, callback) {
       if (!baseUrl.query) {
         baseUrl.query = Url.parse(url).query;
       }
-      Async.parallel(self.spec.apis.map(function(api) {
-        return function(callback) {
-          resolveNestedAPI(api, baseUrl, callback);
-        }
-      }), function(err, apis) {
-        if (err) throw err;
+      Async.map(self.spec.apis, resolveNestedAPI.bind(self, baseUrl), function (err, apis) {
         self.apis = apis;
-        callback();
+        callback(err);
       });
     });
   }
 }
 
-var resolveNestedAPI = function(api, baseUrl, callback) {
+var resolveNestedAPI = function(baseUrl, api, callback) {
   api.path = api.path.replace('{format}', 'json');
   if (api.operations) {
     var apiBody = {apis: [api]};
@@ -93,9 +89,11 @@ var resolveNestedAPI = function(api, baseUrl, callback) {
   apiUrl = Url.parse(apiUrl);
   if (!apiUrl.query) apiUrl.query = baseUrl.query;
   apiUrl = Url.format(apiUrl);
-  Request(apiUrl, function(err, response, apiBody) {
-    if (err) throw err;
-    apiBody = Types.parse(apiBody);
+  Types.requestUrl(apiUrl, function(err, apiBody) {
+    if (err) {
+      callback(err);
+      return;
+    }
     setAPIDefaults(apiBody, baseUrl);
     callback(null, apiBody);
   })

--- a/lib/types/types.js
+++ b/lib/types/types.js
@@ -1,3 +1,6 @@
+var FS = require('fs');
+var Request = require('request');
+
 var Types = module.exports = {};
 
 Types.base_type = require('./base-type.js');
@@ -37,4 +40,36 @@ Types.parse = function(spec) {
     }
   }
   return spec;
+}
+
+Types.requestUrl = function (url, callback) {
+  Request(url, function(err, response, spec) {
+    if (err) {
+      callback(error);
+      return;
+    }
+    try {
+      spec = Types.parse(spec);
+    } catch(e) {
+      callback(e);
+      return;
+    }
+    callback(null, spec);
+  });
+}
+
+Types.readFile = function (filename, callback) {
+  FS.readFile(filename, 'utf8', function(err, spec) {
+    if (err) {
+      callback(error);
+      return;
+    }
+    try {
+      spec = Types.parse(spec);
+    } catch(e) {
+      callback(e);
+      return;
+    }
+    callback(null, spec);
+  });
 }


### PR DESCRIPTION
Before changes, exceptions occurred inside node's event loop:
>Error: Unsupported format. Spec must be valid JSON or YAML.
    at Object.Types.parse (/home/ivang/dev/internal-scripts/node_modules/api-spec-converter/lib/types/types.js:36:13)
    at Request._callback (/home/ivang/dev/internal-scripts/node_modules/api-spec-converter/lib/types/swagger_1.js:98:21)
    at Request.self.callback (/home/ivang/dev/internal-scripts/node_modules/request/request.js:368:22)
    at Request.EventEmitter.emit (events.js:98:17)
    at Request.<anonymous> (/home/ivang/dev/internal-scripts/node_modules/request/request.js:1219:14)
    at Request.EventEmitter.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/home/ivang/dev/internal-scripts/node_modules/request/request.js:1167:12)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:920:16
    at process._tickCallback (node.js:415:13)