### PR TITLE
Catch exceptions during conversion.

### DIFF
--- a/lib/types/api_blueprint.js
+++ b/lib/types/api_blueprint.js
@@ -3,10 +3,11 @@
 var Inherits = require('util').inherits;
 var BPToSwagger = require('apib2swagger');
 
+var BaseType = require('./base-type.js');
 var Types = require('./types.js');
 
 var APIBlueprint = module.exports = function() {
-  Types.base_type.apply(this, arguments);
+  APIBlueprint.super_.apply(this, arguments);
   this.type = 'api_blueprint';
 
   this.converters.swagger_2 = function(apibp, callback) {
@@ -15,7 +16,7 @@ var APIBlueprint = module.exports = function() {
   }
 }
 
-Inherits(APIBlueprint, Types.base_type);
+Inherits(APIBlueprint, BaseType);
 
 APIBlueprint.prototype.checkFormat = function (spec) {
   //TODO: 'spec.ast' isn't working find other criteria.

--- a/lib/types/api_blueprint.js
+++ b/lib/types/api_blueprint.js
@@ -16,3 +16,8 @@ var APIBlueprint = module.exports = function() {
 }
 
 Inherits(APIBlueprint, Types.base_type);
+
+APIBlueprint.prototype.checkFormat = function (spec) {
+  //TODO: 'spec.ast' isn't working find other criteria.
+  return true;
+}

--- a/lib/types/base-type.js
+++ b/lib/types/base-type.js
@@ -14,10 +14,16 @@ BaseType.prototype.stringify = function() {
   return JSON.stringify(this.spec, null, 2);
 }
 
+BaseType.prototype.checkFormat = undefined;
+
 BaseType.prototype.resolveResources = function(options, callback) {
   var self = this;
   var parseCB = function(err, spec) {
     if (err) return callback(err);
+
+    if (!self.checkFormat(spec))
+      return callback(Error('Incorrect format'));
+
     self.spec = spec;
     callback();
   }

--- a/lib/types/base-type.js
+++ b/lib/types/base-type.js
@@ -2,7 +2,7 @@
 
 var FS = require('fs');
 var YAML = require('yamljs');
-var Types = require('./types.js');
+var Util = require('./util.js');
 
 var BaseType = module.exports = function(spec) {
   if (spec) this.spec = spec;
@@ -28,9 +28,9 @@ BaseType.prototype.resolveResources = function(options, callback) {
     callback();
   }
   if (options.url) {
-    Types.requestUrl(options.url, parseCB)
+    Util.requestUrl(options.url, parseCB)
   } else if (options.file) {
-    Types.readFile(options.file, parseCB);
+    Util.readFile(options.file, parseCB);
   } else if (options.spec) {
     self.spec = options.spec;
     callback();

--- a/lib/types/io_docs.js
+++ b/lib/types/io_docs.js
@@ -51,3 +51,6 @@ var IODocs = module.exports = function() {
 
 Inherits(IODocs, Types.base_type);
 
+IODocs.prototype.checkFormat = function (spec) {
+  return spec.protocol === 'rest';
+}

--- a/lib/types/io_docs.js
+++ b/lib/types/io_docs.js
@@ -5,10 +5,11 @@ var Path = require('path');
 var URL = require('url');
 var _ = require('lodash');
 
+var BaseType = require('./base-type.js');
 var Types = require('./types.js');
 
 var IODocs = module.exports = function() {
-  Types.base_type.apply(this, arguments);
+  IODocs.super_.apply(this, arguments);
   this.type = 'io_docs';
   this.converters = {
     swagger_2: function(iodocs, callback) {
@@ -49,7 +50,7 @@ var IODocs = module.exports = function() {
   }
 }
 
-Inherits(IODocs, Types.base_type);
+Inherits(IODocs, BaseType);
 
 IODocs.prototype.checkFormat = function (spec) {
   return spec.protocol === 'rest';

--- a/lib/types/swagger_1.js
+++ b/lib/types/swagger_1.js
@@ -9,7 +9,7 @@ var ConvertToSwagger2 = require('swagger-converter');
 var Types = require('./types.js');
 
 var Swagger1 = module.exports = function() {
-  Types.base_type.apply(this, arguments);
+  Swagger1.super_.apply(this, arguments);
   this.type = 'swagger_1';
 
   this.converters.swagger_2 = function(swagger1, callback) {
@@ -34,14 +34,13 @@ var containsHost = function(urlString) {
 
 Swagger1.prototype.resolveResources = function(options, callback) {
   var self = this;
+  var resolveCb;
+
   if (options.file) {
-    Types.readFile(options.file, function(err, spec) {
-      if (err) {
-        callback(err);
-        return;
-      }
+    resolveCb = function (err) {
+      if (err) return callback(err);
+
       var dir = Path.dirname(options.file);
-      self.spec = spec;
       var files = self.spec.apis.map(function(api) {
           var filename = Path.join(dir, api.path);
           if (filename.indexOf('.json') === -1) 
@@ -52,15 +51,12 @@ Swagger1.prototype.resolveResources = function(options, callback) {
         self.apis = apis;
         callback(err);
       });
-    });
+    };
   } else if (options.url) {
     var url = options.url;
-    Types.requestUrl(url, function(err, spec) {
-      if (err) {
-        callback(err);
-        return;
-      }
-      self.spec = spec;
+    resolveCb = function (err) {
+      if (err) return callback(err);
+
       var baseUrl = self.spec.basePath;
       if (!baseUrl || !containsHost(baseUrl)) {
         baseUrl = Url.parse(url);
@@ -75,8 +71,9 @@ Swagger1.prototype.resolveResources = function(options, callback) {
         self.apis = apis;
         callback(err);
       });
-    });
+    };
   }
+  Swagger1.super_.prototype.resolveResources.call(this, options, resolveCb);
 }
 
 var resolveNestedAPI = function(baseUrl, api, callback) {

--- a/lib/types/swagger_1.js
+++ b/lib/types/swagger_1.js
@@ -16,7 +16,7 @@ var Swagger1 = module.exports = function() {
     try {
       var swagger2 = ConvertToSwagger2(swagger1.spec, swagger1.apis);
     } catch(e) {
-      callback(Error("Exception during convertion: " + e));
+      callback(Error('Exception during convertion: ' + e));
       return;
     }
     if (swagger2.info.title === 'Title was not specified') {

--- a/lib/types/swagger_1.js
+++ b/lib/types/swagger_1.js
@@ -32,6 +32,10 @@ var containsHost = function(urlString) {
   return url.protocol && url.hostname;
 }
 
+Swagger1.prototype.checkFormat = function (spec) {
+  return ['1.0', '1.1', '1.2'].indexOf(spec.swaggerVersion) !== -1;
+}
+
 Swagger1.prototype.resolveResources = function(options, callback) {
   var self = this;
   var resolveCb;

--- a/lib/types/swagger_1.js
+++ b/lib/types/swagger_1.js
@@ -6,7 +6,9 @@ var Url = require('url');
 var Inherits = require('util').inherits;
 var ConvertToSwagger2 = require('swagger-converter');
 
+var BaseType = require('./base-type.js');
 var Types = require('./types.js');
+var Util = require('./util.js');
 
 var Swagger1 = module.exports = function() {
   Swagger1.super_.apply(this, arguments);
@@ -25,7 +27,8 @@ var Swagger1 = module.exports = function() {
     callback(null, new Types.swagger_2(swagger2));
   }
 }
-Inherits(Swagger1, Types.base_type);
+
+Inherits(Swagger1, BaseType);
 
 var containsHost = function(urlString) {
   var url = Url.parse(urlString);
@@ -51,7 +54,7 @@ Swagger1.prototype.resolveResources = function(options, callback) {
             filename += '.json';
           return filename;
       });
-      Async.map(files, Types.readFile, function (err, apis) {
+      Async.map(files, Util.readFile, function (err, apis) {
         self.apis = apis;
         callback(err);
       });
@@ -96,7 +99,7 @@ var resolveNestedAPI = function(baseUrl, api, callback) {
   apiUrl = Url.parse(apiUrl);
   if (!apiUrl.query) apiUrl.query = baseUrl.query;
   apiUrl = Url.format(apiUrl);
-  Types.requestUrl(apiUrl, function(err, apiBody) {
+  Util.requestUrl(apiUrl, function(err, apiBody) {
     if (err) {
       callback(err);
       return;

--- a/lib/types/swagger_1.js
+++ b/lib/types/swagger_1.js
@@ -13,7 +13,12 @@ var Swagger1 = module.exports = function() {
   this.type = 'swagger_1';
 
   this.converters.swagger_2 = function(swagger1, callback) {
-    var swagger2 = ConvertToSwagger2(swagger1.spec, swagger1.apis);
+    try {
+      var swagger2 = ConvertToSwagger2(swagger1.spec, swagger1.apis);
+    } catch(e) {
+      callback(Error("Exception during convertion: " + e));
+      return;
+    }
     if (swagger2.info.title === 'Title was not specified') {
       swagger2.info.title = swagger2.host;
     }

--- a/lib/types/swagger_2.js
+++ b/lib/types/swagger_2.js
@@ -2,14 +2,15 @@
 
 var Inherits = require('util').inherits;
 
+var BaseType = require('./base-type.js');
 var Types = require('./types.js');
 
 var Swagger2 = module.exports = function() {
-  Types.base_type.apply(this, arguments);
+  Swagger2.super_.apply(this, arguments);
   this.type = 'swagger_2';
 }
 
-Inherits(Swagger2, Types.base_type);
+Inherits(Swagger2, BaseType);
 
 Swagger2.prototype.checkFormat = function (spec) {
   return spec.swagger === '2.0';

--- a/lib/types/swagger_2.js
+++ b/lib/types/swagger_2.js
@@ -11,3 +11,7 @@ var Swagger2 = module.exports = function() {
 
 Inherits(Swagger2, Types.base_type);
 
+Swagger2.prototype.checkFormat = function (spec) {
+  return spec.swagger === '2.0';
+}
+

--- a/lib/types/types.js
+++ b/lib/types/types.js
@@ -1,65 +1,8 @@
 'use strict';
 
-var FS = require('fs');
-var Request = require('request');
-var Protagonist = require('protagonist');
-
 var Types = module.exports = {};
 
-Types.base_type = require('./base-type.js');
 Types.swagger_1 = require('./swagger_1.js');
 Types.swagger_2 = require('./swagger_2.js');
 Types.api_blueprint = require('./api_blueprint.js');
 Types.io_docs = require('./io_docs.js');
-
-Types.getType = function(spec) {
-  if (spec.ast) return 'api_blueprint';
-  var swagger = spec.swagger || spec.swaggerVersion;
-  if (!swagger) {
-    throw new Error("Unsupported spec type");
-  }
-  if (typeof swagger !== 'string') swagger = swagger.toString();
-
-  if (swagger.indexOf('1') === 0) return 'swagger_1';
-  else if (swagger.indexOf('2') === 0) return 'swagger_2';
-  else throw new Error("Unsupported Swagger version");
-}
-
-Types.parse = function(spec, callback) {
-  var parsed = null;
-
-  try {
-    parsed = JSON.parse(spec);
-  } catch(e) {}
-  if (parsed) return callback(null, parsed);
-
-  try {
-    parsed = YAML.parse(spec);
-  } catch(e) {}
-  if (parsed) return callback(null, parsed);
-
-  Protagonist.parse(spec, function(err, apibp) {
-    if (err) return callback(new Error("Unsupported format. Spec must be valid JSON, YAML, or Markdown"));
-    else return callback(null, apibp.ast);
-  });
-}
-
-Types.requestUrl = function (url, callback) {
-  Request(url, function(err, response, spec) {
-    if (err) {
-      callback(err);
-      return;
-    }
-    Types.parse(spec, callback);
-  });
-}
-
-Types.readFile = function (filename, callback) {
-  FS.readFile(filename, 'utf8', function(err, spec) {
-    if (err) {
-      callback(err);
-      return;
-    }
-    Types.parse(spec, callback);
-  });
-}

--- a/lib/types/util.js
+++ b/lib/types/util.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var FS = require('fs');
+var Request = require('request');
+var Protagonist = require('protagonist');
+
+module.exports.parse = function(spec, callback) {
+  var parsed = null;
+
+  try {
+    parsed = JSON.parse(spec);
+  } catch(e) {}
+  if (parsed) return callback(null, parsed);
+
+  try {
+    parsed = YAML.parse(spec);
+  } catch(e) {}
+  if (parsed) return callback(null, parsed);
+
+  Protagonist.parse(spec, function(err, apibp) {
+    if (err) return callback(new Error("Unsupported format. Spec must be valid JSON, YAML, or Markdown"));
+    else return callback(null, apibp.ast);
+  });
+}
+
+module.exports.requestUrl = function (url, callback) {
+  Request(url, function(err, response, spec) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    module.exports.parse(spec, callback);
+  });
+}
+
+module.exports.readFile = function (filename, callback) {
+  FS.readFile(filename, 'utf8', function(err, spec) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    module.exports.parse(spec, callback);
+  });
+}
+


### PR DESCRIPTION
If other converters, also reports errors as exceptions, then we need to make it generic code.