### PR TITLE
Add function to get type based on format&version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var Types = require('./lib/types/types.js');
+var _ = require('lodash');
 
 var Converter = module.exports = {};
 
-Converter.getSpec = function (source, format, callback) {
-  var spec = new Types[format]();
+Converter.getSpec = function (source, type, callback) {
+  var spec = new Types[type]();
   spec.resolveResources(source, function(error) {
     if (error)
       callback(error, null);
@@ -13,6 +14,16 @@ Converter.getSpec = function (source, format, callback) {
       callback(null, spec);
   });
 }
+
+Converter.getTypeName = function (name, version) {
+  var result;
+  _.each(Types, function (type, typeName) {
+    type = type.prototype;
+    if (type.formatName === name && type.supportedVersions.indexOf(version) !== -1)
+      result = typeName;
+  });
+  return result;
+};
 
 Converter.convert = function(options, callback) {
   Converter.getSpec(options.source, options.from, function(error, fromSpec) {

--- a/lib/types/api_blueprint.js
+++ b/lib/types/api_blueprint.js
@@ -20,6 +20,7 @@ var APIBlueprint = module.exports = function() {
 Inherits(APIBlueprint, BaseType);
 
 APIBlueprint.prototype.formatName = 'apiBlueprint';
+APIBlueprint.prototype.supportedVersions = ['1A'];
 APIBlueprint.prototype.getFormatVersion = function () {
   //TODO: check version in file.
   return '1A';

--- a/lib/types/base-type.js
+++ b/lib/types/base-type.js
@@ -68,6 +68,9 @@ BaseType.prototype.resolveResources = function(options, callback) {
 }
 
 BaseType.prototype.convertTo = function(type, callback) {
+  if (type === this.type)
+    callback(null, this);
+
   var convert = this.converters[type];
   if (!convert) {
     throw new Error("Unable to convert from " + this.type + " to " + type);

--- a/lib/types/google.js
+++ b/lib/types/google.js
@@ -25,6 +25,7 @@ var Google = module.exports = function() {
 Inherits(Google, BaseType);
 
 Google.prototype.formatName = 'google';
+Google.prototype.supportedVersions = ['v1'];
 Google.prototype.getFormatVersion = function () {
   return Google2Swagger.getVersion(this.spec);
 }

--- a/lib/types/io_docs.js
+++ b/lib/types/io_docs.js
@@ -54,6 +54,7 @@ var IODocs = module.exports = function() {
 Inherits(IODocs, BaseType);
 
 IODocs.prototype.formatName = 'ioDocs';
+IODocs.prototype.supportedVersions = ['1.0'];
 IODocs.prototype.getFormatVersion = function () {
   //It's looks like format doesn't have versions, so treat it as '1.0'
   return '1.0';

--- a/lib/types/swagger_1.js
+++ b/lib/types/swagger_1.js
@@ -37,6 +37,7 @@ var containsHost = function(urlString) {
 }
 
 Swagger1.prototype.formatName = 'swagger';
+Swagger1.prototype.supportedVersions = ['1.0', '1.1', '1.2'];
 Swagger1.prototype.getFormatVersion = function () {
   return this.spec.swaggerVersion;
 }

--- a/lib/types/swagger_2.js
+++ b/lib/types/swagger_2.js
@@ -14,6 +14,7 @@ var Swagger2 = module.exports = function() {
 Inherits(Swagger2, BaseType);
 
 Swagger2.prototype.formatName = 'swagger';
+Swagger2.prototype.supportedVersions = ['2.0'];
 Swagger2.prototype.getFormatVersion = function () {
   return this.spec.swagger;
 }


### PR DESCRIPTION
Also because it already stable release we need to update version properly.
What do you think about [this](http://semver.org/spec/v2.0.0.html) standard?

Also you could simplify npm releases by using [Travis](http://docs.travis-ci.com/user/deployment/npm/)