### PR TITLE
Correct path concatenation

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,8 @@ var URI = require('urijs');
 var traverse = require('traverse');
 
 module.exports.joinPath = function () {
-  return Path.join.apply(null, arguments).replace(/\\/g, '/');
+  var argArray = Array.prototype.slice.call(arguments);
+  return argArray.join('/').replace(/\/\/+/g, '/')
 }
 
 module.exports.parseJSON = function (data, callback) {


### PR DESCRIPTION
More OS independent way.
Plus will work if `\\` used inside path. 