### PR TITLE
Limit number of parallel downloads to 5

### DIFF
--- a/lib/base-type.js
+++ b/lib/base-type.js
@@ -38,7 +38,8 @@ BaseType.prototype.listSubResources = function () {
 
 BaseType.prototype.resolveSubResources = function (callback) {
   var sources = this.listSubResources();
-  Async.map(_.values(sources), this.readSpec.bind(this),
+  //Limit number of parallel downloads to 5
+  Async.mapLimit(_.values(sources), 5, this.readSpec.bind(this),
     function (err, resources) {
       if (err)
         return callback(err);


### PR DESCRIPTION
Some APIs have huge number of external references, for example, this one:
http://geodesystems.com/repository/swagger/api-docs